### PR TITLE
fix: deploy pages from master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,9 @@ name: Deploy site to GitHub Pages
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - master
   workflow_dispatch:
 
 permissions:

--- a/docs/status.md
+++ b/docs/status.md
@@ -15,6 +15,7 @@
 - Refreshed styling to accommodate multi-panel layout and reusable field styles.
 - Established documentation structure (`README.md`, `docs/`, `AGENTS.md`).
 - Automated GitHub Pages deployment through a build-and-publish workflow targeting the `gh-pages` branch.
+- Adjusted GitHub Pages workflow triggers so deployments run from `main` or the legacy `master` branch.
 
 ## In Progress / Needs Attention
 


### PR DESCRIPTION
## Summary
- allow the GitHub Pages workflow to trigger when commits land on `main` or `master`
- document the workflow change in the project status log so deploy expectations stay current

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e5483181d083298d4ebad23a35318d