### PR TITLE
Add class selection flow and integrate class defaults

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,8 +15,10 @@ src/
   App.css                # Global panel + field styling
   components/
     CharacterIdentitySection.tsx
+    ClassSelectionSection.tsx
     CombatStatsSection.tsx
   lib/
+    classes.ts           # Class metadata, helpers for defaults & summaries
     dice.ts              # Dice parsing, RNG helpers, method metadata
   schema/
     character.ts         # Zod schema, defaults, alignment/combat options
@@ -30,22 +32,29 @@ Public assets live in `public/`; Vite handles asset inlining under `src/assets/`
 
 `App.tsx` wraps the sheet in `FormProvider`, exposing:
 
-- **CharacterIdentitySection** – Captures name, class, ancestry, background, alignment, and player info. Uses datalists for quick suggestions and displays inline validation.
-- **CombatStatsSection** – Collects AC, initiative bonus, speed, hit points, and hit dice with bounded numeric inputs and helper copy.
-- **Ability Score Roller Panel** – Presents dice method selector, optional expression input, and roll trigger.
+- **CharacterIdentitySection** – Captures name, level, ancestry, background, alignment, and player info. Uses datalists for quick suggestions and displays inline validation.
+- **ClassSelectionSection** – Presents a SRD-compliant class list, subclass picker, prepared-spell toggle, and fighting style radios backed by class metadata. Emits helper text describing hit dice, primary abilities, and saving throws.
+- **CombatStatsSection** – Collects AC, initiative bonus, speed, hit points, and hit dice with bounded numeric inputs, plus class-aware recommendations and an "apply defaults" action.
+- **Ability Score Roller Panel** – Presents dice method selector, optional expression input, and roll trigger; now surfaces the selected class’ primary ability.
 - **Current Scores Panel** – Renders six ability score cards with calculated modifiers.
 
 Every panel uses the shared `panel` styling for a consistent parchment card aesthetic; components can opt into `panel--span-2` when they should stretch across the grid.
 
 ## State & Validation Flow
 
-1. `characterFormSchema` defines `diceMethod`, `diceExpression`, `abilityScores`, `identity`, and `combat`.
-2. `useForm` seeds defaults derived from dice utilities, identity constants, and `defaultCombatStats` (AC 12, HP 10, speed 30).
+1. `characterFormSchema` defines `diceMethod`, `diceExpression`, `abilityScores`, `identity`, `classSelection`, and `combat`.
+2. `useForm` seeds defaults derived from dice utilities, identity constants, `defaultClassSelection`, and `defaultCombatStats` (derived from the default class at level 1).
 3. When dice method changes, the app recalculates ability scores via `rollAbilityScores` (passing expressions where necessary).
-4. Combat inputs stay controlled via React Hook Form and Zod, which clamps numeric ranges and prevents current HP from exceeding max HP.
+4. Combat inputs stay controlled via React Hook Form and Zod, which clamps numeric ranges, prevents current HP from exceeding max HP, and provides class-derived guidance without forcing overrides.
 5. Custom expressions leverage `parseDiceExpression` to ensure safe, bounded rolling before touching form state.
 
 ## Dice Utilities
+
+`lib/classes.ts` houses reusable class metadata:
+
+- `CLASS_DEFINITIONS` tracks SRD-friendly class, subclass, fighting style, and spellcasting info.
+- `getClassDefaults` returns hit dice strings, baseline hit points, and ability/saving throw summaries.
+- `classOptions`, `getSubclassOptions`, and validation helpers ensure the schema + UI stay in sync.
 
 `lib/dice.ts` standardises all rolling logic:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -32,7 +32,12 @@ Automated testing is not yet configured; rely on the following manual checks:
    - Switch between each predefined method.
    - Enter valid/invalid custom expressions (e.g. `4d6`, `2d8+3`, `3d6-1`, `banana`). Confirm error states and disabled roll button.
 3. Verify identity form validation triggers when fields are left blank and recovers on fix.
-4. Adjust combat fields (AC, HP, speed) to ensure min/max limits and HP > Max validation behave as expected.
+4. Walk through class selection:
+   - Choose a class with subclasses (e.g. Cleric) and ensure the subclass select enforces a choice.
+   - Toggle to a martial class (Fighter, Paladin, Ranger) and confirm fighting style radios appear and persist per class.
+   - Switch to a prepared caster (Cleric, Druid, Wizard) and confirm the prepared-spell checkbox toggles without leaking to non-prepared classes.
+   - Apply class defaults from the combat panel and verify hit dice / max HP update without overwriting custom current HP unless needed.
+5. Adjust combat fields (AC, HP, speed) to ensure min/max limits and HP > Max validation behave as expected.
 
 Additions to the dice parser or schema should include unit coverage (e.g., Vitest) in future iterations; see `docs/status.md` for current testing roadmap.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -16,6 +16,8 @@
 - Established documentation structure (`README.md`, `docs/`, `AGENTS.md`).
 - Automated GitHub Pages deployment through a build-and-publish workflow targeting the `gh-pages` branch.
 - Adjusted GitHub Pages workflow triggers so deployments run from `main` or the legacy `master` branch.
+- Delivered class selection flow with SRD class metadata, subclass enforcement, fighting style radios, and prepared-spell toggle backed by new `lib/classes.ts` helpers.
+- Surfaced class-derived defaults in the combat panel, including an "apply defaults" action and ability-focused copy in the ability roller.
 
 ## In Progress / Needs Attention
 
@@ -25,12 +27,11 @@
 
 ## Next Steps
 
-1. **Class Selection Slice** - Introduce structured class data (base class list plus optional archetypes), extend `schema/character.ts` and form types, add a `ClassSelectionSection`, and propagate class defaults (hit dice, proficiency hints) into the combat panel.
-2. **Form Expansion** - Continue the panel pattern for skills, equipment, spellcasting, and session notes once class selection is stable.
-3. **Persistence** - Implement localStorage autosave plus import/export of character JSON for cross-session editing.
-4. **Validation Enhancements** - Extend dice parser for advanced mechanics (keep/drop dice, advantage/disadvantage) and ensure class-derived constraints stay coherent.
-5. **Testing** - Stand up Vitest plus React Testing Library, prioritising coverage for `ClassSelectionSection`, `schema/character.ts`, and existing dice utilities.
-6. **Design Polish** - Create a print-friendly layout or PDF export after the new panels land.
+1. **Form Expansion** - Continue the panel pattern for skills, equipment, spellcasting, and session notes building on the new class infrastructure.
+2. **Persistence** - Implement localStorage autosave plus import/export of character JSON for cross-session editing.
+3. **Validation Enhancements** - Extend dice parser for advanced mechanics (keep/drop dice, advantage/disadvantage) and ensure class-derived constraints stay coherent.
+4. **Testing** - Stand up Vitest plus React Testing Library, prioritising coverage for `ClassSelectionSection`, `schema/character.ts`, and existing dice utilities.
+5. **Design Polish** - Create a print-friendly layout or PDF export after the new panels land.
 
 ## Open Questions
 

--- a/src/App.css
+++ b/src/App.css
@@ -87,6 +87,30 @@
   box-shadow: none;
 }
 
+.button {
+  align-self: flex-start;
+  border-radius: 999px;
+  border: 1px solid #613dc1;
+  background: rgba(97, 61, 193, 0.08);
+  color: #3d2b6d;
+  padding: 0.55rem 1.5rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, opacity 120ms ease;
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(97, 61, 193, 0.2);
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
 .helper-text {
   margin: 0;
   font-size: 0.9rem;
@@ -97,10 +121,21 @@
   border: 1px dashed rgba(160, 91, 51, 0.6);
 }
 
+.helper-text--stack {
+  display: grid;
+  gap: 0.5rem;
+}
+
 .identity-grid {
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.class-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .combat-grid {
@@ -116,6 +151,11 @@
 }
 
 .field label {
+  font-weight: 600;
+  color: #3d3326;
+}
+
+.field__label {
   font-weight: 600;
   color: #3d3326;
 }
@@ -225,6 +265,58 @@
   margin: 0;
   font-size: 0.85rem;
   color: #6f5e4b;
+}
+
+.option-stack {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.option-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid #cdb99d;
+  background: #fffdf7;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.04);
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.option-card:focus-within {
+  border-color: #613dc1;
+  box-shadow: 0 0 0 3px rgba(97, 61, 193, 0.18);
+}
+
+.option-card input[type="radio"] {
+  margin-top: 0.2rem;
+}
+
+.option-card__label {
+  margin: 0 0 0.25rem;
+  font-weight: 600;
+  color: #3d3326;
+}
+
+.option-card__description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #6f5e4b;
+}
+
+.checkbox-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: #3d3326;
+}
+
+.checkbox-field input[type="checkbox"] {
+  width: 1.1rem;
+  height: 1.1rem;
 }
 
 .helper-text--muted {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,14 +15,21 @@ import {
   rollAbilityScores,
 } from "./lib/dice"
 import {
+  formatSavingThrows,
+  getClassDefaults,
+  getClassDefinition,
+} from "./lib/classes"
+import {
   characterFormSchema,
   createBlankAbilityScores,
   defaultCharacterIdentity,
+  defaultClassSelection,
   defaultCombatStats,
   defaultDiceExpressionValue,
   type CharacterFormInput,
 } from "./schema/character"
 import { CharacterIdentitySection } from "./components/CharacterIdentitySection"
+import { ClassSelectionSection } from "./components/ClassSelectionSection"
 import { CombatStatsSection } from "./components/CombatStatsSection"
 import "./App.css"
 const DEFAULT_METHOD: DiceMethodId = "four_d6_drop_lowest"
@@ -44,6 +51,7 @@ function App() {
       diceExpression: defaultDiceExpressionValue,
       abilityScores: initialAbilityScores,
       identity: defaultCharacterIdentity,
+      classSelection: defaultClassSelection,
       combat: defaultCombatStats,
     },
   })
@@ -61,7 +69,23 @@ function App() {
   const methodId = watch("diceMethod") ?? DEFAULT_METHOD
   const diceExpression = watch("diceExpression") ?? defaultDiceExpressionValue
   const abilityScores = watch("abilityScores")
+  const classSelection = watch("classSelection")
+  const level = watch("identity.level") ?? defaultCharacterIdentity.level
   const selectedMethod = useMemo(() => getDiceMethod(methodId), [methodId])
+  const classDefaults = useMemo(() => {
+    if (!classSelection) {
+      return null
+    }
+
+    return getClassDefaults(classSelection.classId, level)
+  }, [classSelection, level])
+  const classDefinition = useMemo(() => {
+    if (!classSelection) {
+      return null
+    }
+
+    return getClassDefinition(classSelection.classId)
+  }, [classSelection])
 
   const expressionRegister = register("diceExpression", {
     onChange: () => {
@@ -131,6 +155,7 @@ function App() {
     <FormProvider {...form}>
       <main className="app-shell">
         <CharacterIdentitySection />
+        <ClassSelectionSection />
         <CombatStatsSection />
 
         <section className="panel">
@@ -138,6 +163,15 @@ function App() {
             <h2>Ability Score Roller</h2>
             <p>Choose a dice method to seed your character&apos;s six ability scores.</p>
           </header>
+
+          {classDefaults && classDefinition && (
+            <p className="helper-text helper-text--muted">
+              The {classDefinition.label} favors {abilityScoreLabels[classDefaults.primaryAbility]}
+              {" "}
+              and is proficient in {formatSavingThrows(classDefaults.savingThrows)} saving throws.
+              Consider prioritising that ability when you assign rolls.
+            </p>
+          )}
 
           <div className="method-picker">
             <label htmlFor="dice-method">Dice method</label>

--- a/src/components/CharacterIdentitySection.tsx
+++ b/src/components/CharacterIdentitySection.tsx
@@ -65,19 +65,6 @@ export const CharacterIdentitySection = () => {
           )}
         </div>
 
-        <div className="field">
-          <label htmlFor="class-name">Class</label>
-          <input
-            id="class-name"
-            type="text"
-            placeholder="Bard"
-            {...register("identity.className")}
-          />
-          {getError("className") && (
-            <p className="field__error">{getError("className")}</p>
-          )}
-        </div>
-
         <div className="field field--compact">
           <label htmlFor="level">Level</label>
           <input

--- a/src/components/ClassSelectionSection.tsx
+++ b/src/components/ClassSelectionSection.tsx
@@ -1,0 +1,267 @@
+import { useMemo, useRef } from "react"
+import type { ChangeEvent } from "react"
+import { useFormContext, useWatch } from "react-hook-form"
+import type { ClassId } from "../types/character"
+import { abilityScoreLabels } from "../types/character"
+import type { CharacterFormInput } from "../schema/character"
+import {
+  classOptions,
+  formatSavingThrows,
+  getClassDefaults,
+  getClassDefinition,
+  getFightingStyleOptions,
+  getSubclassOptions,
+  hasPreparedSpellcasting,
+  spellcastingStyleLabels,
+} from "../lib/classes"
+
+type ClassSelectionField = keyof CharacterFormInput["classSelection"]
+
+type ClassSelectionErrors =
+  | Partial<Record<ClassSelectionField, { message?: string }>>
+  | undefined
+
+type SelectionMemory = Partial<Record<ClassId, string | null>>
+type PreparationMemory = Partial<Record<ClassId, boolean>>
+
+export const ClassSelectionSection = () => {
+  const {
+    register,
+    setValue,
+    clearErrors,
+    getValues,
+    control,
+    formState: { errors },
+  } = useFormContext<CharacterFormInput>()
+
+  const classSelection = useWatch<CharacterFormInput, "classSelection">({
+    control,
+    name: "classSelection",
+  })
+  const level =
+    useWatch<CharacterFormInput, "identity.level">({
+      control,
+      name: "identity.level",
+    }) ?? 1
+
+  const selectedClassId = classSelection?.classId
+  const classDefinition = selectedClassId
+    ? getClassDefinition(selectedClassId)
+    : null
+  const subclassOptions = selectedClassId
+    ? getSubclassOptions(selectedClassId)
+    : []
+  const fightingStyleOptions = selectedClassId
+    ? getFightingStyleOptions(selectedClassId)
+    : []
+  const classDefaults = useMemo(() => {
+    if (!selectedClassId) {
+      return null
+    }
+
+    return getClassDefaults(selectedClassId, level)
+  }, [selectedClassId, level])
+
+  const classSelectionErrors = errors.classSelection as ClassSelectionErrors
+  const getError = (field: ClassSelectionField) =>
+    classSelectionErrors?.[field]?.message
+
+  const subclassMemory = useRef<SelectionMemory>({})
+  const fightingStyleMemory = useRef<SelectionMemory>({})
+  const preparationMemory = useRef<PreparationMemory>({})
+
+  const showSubclassPicker = subclassOptions.length > 0
+  const showFightingStyles = fightingStyleOptions.length > 0
+  const showPreparationToggle = Boolean(
+    selectedClassId && hasPreparedSpellcasting(selectedClassId),
+  )
+
+  const classIdRegister = register("classSelection.classId", {
+    onChange: (event: ChangeEvent<HTMLSelectElement>) => {
+      const currentClassId = getValues("classSelection.classId") as ClassId | null
+      if (currentClassId) {
+        subclassMemory.current[currentClassId] =
+          getValues("classSelection.subclassId") ?? null
+        fightingStyleMemory.current[currentClassId] =
+          getValues("classSelection.fightingStyleId") ?? null
+        preparationMemory.current[currentClassId] = getValues(
+          "classSelection.preparesSpells",
+        )
+      }
+
+      const nextClass = event.target.value as ClassId
+
+      const nextSubclass = subclassMemory.current[nextClass] ?? null
+      const nextFightingStyle = fightingStyleMemory.current[nextClass] ?? null
+      const storedPreparation = preparationMemory.current[nextClass]
+      const shouldPrepare = hasPreparedSpellcasting(nextClass)
+
+      setValue("classSelection.subclassId", nextSubclass, {
+        shouldDirty: true,
+        shouldValidate: true,
+      })
+      setValue("classSelection.fightingStyleId", nextFightingStyle, {
+        shouldDirty: true,
+        shouldValidate: true,
+      })
+      setValue(
+        "classSelection.preparesSpells",
+        shouldPrepare ? storedPreparation ?? true : false,
+        {
+          shouldDirty: true,
+          shouldValidate: true,
+        },
+      )
+      clearErrors([
+        "classSelection.subclassId",
+        "classSelection.fightingStyleId",
+        "classSelection.preparesSpells",
+      ])
+    },
+  })
+
+  const subclassRegister = register("classSelection.subclassId", {
+    setValueAs: (value: string | null) => (value ? value : null),
+    onChange: (event: ChangeEvent<HTMLSelectElement>) => {
+      if (!selectedClassId) {
+        return
+      }
+      const value = event.target.value
+      subclassMemory.current[selectedClassId] = value ? value : null
+    },
+  })
+
+  const fightingStyleRegister = register("classSelection.fightingStyleId", {
+    onChange: (event: ChangeEvent<HTMLInputElement>) => {
+      if (!selectedClassId) {
+        return
+      }
+      const value = event.target.value
+      fightingStyleMemory.current[selectedClassId] = value ? value : null
+    },
+  })
+
+  const preparationRegister = register("classSelection.preparesSpells", {
+    onChange: (event: ChangeEvent<HTMLInputElement>) => {
+      if (!selectedClassId) {
+        return
+      }
+      preparationMemory.current[selectedClassId] = event.target.checked
+    },
+  })
+
+  const metadataSegments = useMemo(() => {
+    if (!classDefaults) {
+      return [] as string[]
+    }
+
+    const segments: string[] = [
+      `Hit Die: ${classDefaults.hitDie}`,
+      `Primary Ability: ${abilityScoreLabels[classDefaults.primaryAbility]}`,
+      `Saving Throws: ${formatSavingThrows(classDefaults.savingThrows)}`,
+    ]
+
+    if (classDefaults.spellcasting) {
+      const styleLabel = spellcastingStyleLabels[classDefaults.spellcasting.style]
+      const focusLabel = classDefaults.spellcasting.focus
+      segments.push(
+        focusLabel ? `${styleLabel} (${focusLabel})` : styleLabel,
+      )
+    }
+
+    return segments
+  }, [classDefaults])
+
+  return (
+    <section className="panel panel--span-2">
+      <header className="panel__header">
+        <h2>Class & Archetype</h2>
+        <p>Choose a class to unlock archetypes, spellcasting notes, and combat defaults.</p>
+      </header>
+
+      {metadataSegments.length > 0 && (
+        <p className="helper-text helper-text--muted">
+          {metadataSegments.join(" • ")}
+        </p>
+      )}
+
+      <div className="class-grid">
+        <div className="field">
+          <label htmlFor="character-class">Class</label>
+          <select id="character-class" {...classIdRegister}>
+            {classOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {showSubclassPicker && (
+          <div className="field">
+            <label htmlFor="character-subclass">Subclass</label>
+            <select id="character-subclass" {...subclassRegister}>
+              <option value="">Select a subclass</option>
+              {subclassOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            {getError("subclassId") && (
+              <p className="field__error">{getError("subclassId")}</p>
+            )}
+          </div>
+        )}
+
+        {showFightingStyles && (
+          <div className="field field--span-2">
+            <span className="field__label">Fighting Style</span>
+            <div className="option-stack">
+              {fightingStyleOptions.map((option) => (
+                <label className="option-card" key={option.id}>
+                  <input
+                    type="radio"
+                    value={option.id}
+                    {...fightingStyleRegister}
+                    checked={classSelection?.fightingStyleId === option.id}
+                  />
+                  <div>
+                    <p className="option-card__label">{option.label}</p>
+                    {option.description && (
+                      <p className="option-card__description">{option.description}</p>
+                    )}
+                  </div>
+                </label>
+              ))}
+            </div>
+            {getError("fightingStyleId") && (
+              <p className="field__error">{getError("fightingStyleId")}</p>
+            )}
+          </div>
+        )}
+
+        {showPreparationToggle && (
+          <div className="field field--span-2">
+            <label className="checkbox-field">
+              <input
+                type="checkbox"
+                {...preparationRegister}
+                checked={classSelection?.preparesSpells ?? false}
+              />
+              <span>Track prepared spells for this class</span>
+            </label>
+            {classDefinition?.spellcasting?.preparationLabel && (
+              <p className="field__description">
+                {classDefinition.spellcasting.preparationLabel}
+              </p>
+            )}
+            {getError("preparesSpells") && (
+              <p className="field__error">{getError("preparesSpells")}</p>
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/lib/classes.ts
+++ b/src/lib/classes.ts
@@ -1,0 +1,298 @@
+import {
+  abilityScoreLabels,
+  type AbilityScoreKey,
+  type ClassId,
+  type ClassOption,
+  type FightingStyleOption,
+  type SpellcastingMeta,
+  type SpellcastingStyle,
+  type SubclassOption,
+} from "../types/character"
+
+type ClassDefinition = {
+  id: ClassId
+  label: string
+  hitDie: number
+  primaryAbility: AbilityScoreKey
+  savingThrows: AbilityScoreKey[]
+  subclasses?: SubclassOption[]
+  spellcasting?: SpellcastingMeta
+  fightingStyles?: FightingStyleOption[]
+  description?: string
+}
+
+type ClassDefinitionRecord = Record<ClassId, ClassDefinition>
+
+const coreFightingStyles: FightingStyleOption[] = [
+  { id: "archery", label: "Archery", description: "+2 bonus to ranged attack rolls." },
+  { id: "defense", label: "Defense", description: "+1 bonus to AC while wearing armor." },
+  { id: "dueling", label: "Dueling", description: "+2 damage with a single one-handed weapon." },
+  { id: "great_weapon_fighting", label: "Great Weapon Fighting", description: "Reroll 1s or 2s on two-handed weapon damage." },
+  { id: "protection", label: "Protection", description: "Impose disadvantage on attacks vs. allies when using a shield." },
+  { id: "two_weapon_fighting", label: "Two-Weapon Fighting", description: "Add ability mod to off-hand damage." },
+]
+
+export const CLASS_DEFINITIONS: ClassDefinitionRecord = {
+  barbarian: {
+    id: "barbarian",
+    label: "Barbarian",
+    hitDie: 12,
+    primaryAbility: "strength",
+    savingThrows: ["strength", "constitution"],
+    subclasses: [
+      { id: "path_of_the_berserker", label: "Path of the Berserker" },
+      { id: "path_of_the_totem_warrior", label: "Path of the Totem Warrior" },
+      { id: "path_of_wild_magic", label: "Path of Wild Magic" },
+    ],
+  },
+  bard: {
+    id: "bard",
+    label: "Bard",
+    hitDie: 8,
+    primaryAbility: "charisma",
+    savingThrows: ["dexterity", "charisma"],
+    subclasses: [
+      { id: "college_of_lore", label: "College of Lore" },
+      { id: "college_of_valor", label: "College of Valor" },
+      { id: "college_of_glamour", label: "College of Glamour" },
+    ],
+    spellcasting: {
+      style: "spells_known",
+      focus: "Instrument or Arcane Focus",
+    },
+  },
+  cleric: {
+    id: "cleric",
+    label: "Cleric",
+    hitDie: 8,
+    primaryAbility: "wisdom",
+    savingThrows: ["wisdom", "charisma"],
+    subclasses: [
+      { id: "life_domain", label: "Life Domain" },
+      { id: "light_domain", label: "Light Domain" },
+      { id: "tempest_domain", label: "Tempest Domain" },
+    ],
+    spellcasting: {
+      style: "prepared",
+      focus: "Holy Symbol",
+      preparationLabel: "Prepare spells after long rests",
+    },
+  },
+  druid: {
+    id: "druid",
+    label: "Druid",
+    hitDie: 8,
+    primaryAbility: "wisdom",
+    savingThrows: ["intelligence", "wisdom"],
+    subclasses: [
+      { id: "circle_of_the_moon", label: "Circle of the Moon" },
+      { id: "circle_of_the_land", label: "Circle of the Land" },
+      { id: "circle_of_stars", label: "Circle of Stars" },
+    ],
+    spellcasting: {
+      style: "prepared",
+      focus: "Druidic Focus",
+      preparationLabel: "Prepare spells after long rests",
+    },
+  },
+  fighter: {
+    id: "fighter",
+    label: "Fighter",
+    hitDie: 10,
+    primaryAbility: "strength",
+    savingThrows: ["strength", "constitution"],
+    subclasses: [
+      { id: "champion", label: "Champion" },
+      { id: "battle_master", label: "Battle Master" },
+      { id: "eldritch_knight", label: "Eldritch Knight" },
+    ],
+    fightingStyles: coreFightingStyles,
+  },
+  monk: {
+    id: "monk",
+    label: "Monk",
+    hitDie: 8,
+    primaryAbility: "dexterity",
+    savingThrows: ["strength", "dexterity"],
+    subclasses: [
+      { id: "way_of_the_open_hand", label: "Way of the Open Hand" },
+      { id: "way_of_shadow", label: "Way of Shadow" },
+      { id: "way_of_four_elements", label: "Way of the Four Elements" },
+    ],
+  },
+  paladin: {
+    id: "paladin",
+    label: "Paladin",
+    hitDie: 10,
+    primaryAbility: "charisma",
+    savingThrows: ["wisdom", "charisma"],
+    subclasses: [
+      { id: "oath_of_devotion", label: "Oath of Devotion" },
+      { id: "oath_of_vengeance", label: "Oath of Vengeance" },
+      { id: "oath_of_the_ancients", label: "Oath of the Ancients" },
+    ],
+    spellcasting: {
+      style: "prepared",
+      focus: "Holy Symbol",
+      preparationLabel: "Prepare a limited list of spells",
+    },
+    fightingStyles: coreFightingStyles.filter((style) =>
+      ["defense", "dueling", "great_weapon_fighting", "protection"].includes(style.id),
+    ),
+  },
+  ranger: {
+    id: "ranger",
+    label: "Ranger",
+    hitDie: 10,
+    primaryAbility: "dexterity",
+    savingThrows: ["strength", "dexterity"],
+    subclasses: [
+      { id: "hunter", label: "Hunter" },
+      { id: "beast_master", label: "Beast Master" },
+      { id: "gloom_stalker", label: "Gloom Stalker" },
+    ],
+    spellcasting: {
+      style: "spells_known",
+      focus: "Druidic Focus or Component Pouch",
+    },
+    fightingStyles: coreFightingStyles.filter((style) =>
+      ["archery", "defense", "dueling", "two_weapon_fighting"].includes(style.id),
+    ),
+  },
+  rogue: {
+    id: "rogue",
+    label: "Rogue",
+    hitDie: 8,
+    primaryAbility: "dexterity",
+    savingThrows: ["dexterity", "intelligence"],
+    subclasses: [
+      { id: "thief", label: "Thief" },
+      { id: "assassin", label: "Assassin" },
+      { id: "arcane_trickster", label: "Arcane Trickster" },
+    ],
+  },
+  sorcerer: {
+    id: "sorcerer",
+    label: "Sorcerer",
+    hitDie: 6,
+    primaryAbility: "charisma",
+    savingThrows: ["constitution", "charisma"],
+    subclasses: [
+      { id: "draconic_bloodline", label: "Draconic Bloodline" },
+      { id: "wild_magic", label: "Wild Magic" },
+      { id: "divine_soul", label: "Divine Soul" },
+    ],
+    spellcasting: {
+      style: "spells_known",
+      focus: "Arcane Focus or Component Pouch",
+    },
+  },
+  warlock: {
+    id: "warlock",
+    label: "Warlock",
+    hitDie: 8,
+    primaryAbility: "charisma",
+    savingThrows: ["wisdom", "charisma"],
+    subclasses: [
+      { id: "the_fiend", label: "The Fiend" },
+      { id: "the_archfey", label: "The Archfey" },
+      { id: "the_great_old_one", label: "The Great Old One" },
+    ],
+    spellcasting: {
+      style: "pact",
+      focus: "Arcane Focus or Pact Implement",
+    },
+  },
+  wizard: {
+    id: "wizard",
+    label: "Wizard",
+    hitDie: 6,
+    primaryAbility: "intelligence",
+    savingThrows: ["intelligence", "wisdom"],
+    subclasses: [
+      { id: "school_of_evocation", label: "School of Evocation" },
+      { id: "school_of_abjuration", label: "School of Abjuration" },
+      { id: "bladesinging", label: "Bladesinging" },
+    ],
+    spellcasting: {
+      style: "prepared",
+      focus: "Arcane Focus or Spellbook",
+      preparationLabel: "Prepare spells from your spellbook",
+    },
+  },
+}
+
+export const classOptions: ClassOption[] = Object.values(CLASS_DEFINITIONS).map(
+  ({ id, label }) => ({ id, label }),
+)
+
+export const spellcastingStyleLabels: Record<SpellcastingStyle, string> = {
+  prepared: "Prepared Spellcasting",
+  spells_known: "Spells Known",
+  pact: "Pact Magic",
+}
+
+export const getClassDefinition = (classId: ClassId): ClassDefinition =>
+  CLASS_DEFINITIONS[classId]
+
+export const getSubclassOptions = (classId: ClassId): SubclassOption[] =>
+  CLASS_DEFINITIONS[classId].subclasses ?? []
+
+export const getFightingStyleOptions = (classId: ClassId): FightingStyleOption[] =>
+  CLASS_DEFINITIONS[classId].fightingStyles ?? []
+
+export const hasPreparedSpellcasting = (classId: ClassId): boolean => {
+  const definition = CLASS_DEFINITIONS[classId]
+  return definition.spellcasting?.style === "prepared"
+}
+
+const averageHitPointsPerLevel = (hitDie: number) => Math.ceil(hitDie / 2) + 1
+
+export interface ClassDefaults {
+  hitDie: string
+  hitDice: string
+  suggestedMaxHitPoints: number
+  primaryAbility: AbilityScoreKey
+  savingThrows: AbilityScoreKey[]
+  spellcasting?: SpellcastingMeta
+}
+
+export const getClassDefaults = (
+  classId: ClassId,
+  level: number,
+): ClassDefaults => {
+  const definition = getClassDefinition(classId)
+  const hitDie = `d${definition.hitDie}`
+  const hitDice = `${level}d${definition.hitDie}`
+  const baseline = definition.hitDie
+  const additionalLevels = Math.max(level - 1, 0)
+  const additionalHp = additionalLevels * averageHitPointsPerLevel(definition.hitDie)
+
+  return {
+    hitDie,
+    hitDice,
+    suggestedMaxHitPoints: baseline + additionalHp,
+    primaryAbility: definition.primaryAbility,
+    savingThrows: definition.savingThrows,
+    spellcasting: definition.spellcasting,
+  }
+}
+
+export const formatSavingThrows = (savingThrows: AbilityScoreKey[]): string =>
+  savingThrows.map((key) => abilityScoreLabels[key]).join(", ")
+
+export const abilityKeyToLabel = (key: AbilityScoreKey): string => abilityScoreLabels[key]
+
+export const getClassAbilitySummary = (classId: ClassId): string => {
+  const definition = getClassDefinition(classId)
+  return abilityScoreLabels[definition.primaryAbility]
+}
+
+export const getClassSavingThrowSummary = (classId: ClassId): string =>
+  formatSavingThrows(getClassDefinition(classId).savingThrows)
+
+export const isSubclassValid = (classId: ClassId, subclassId: string) =>
+  getSubclassOptions(classId).some((option) => option.id === subclassId)
+
+export const isFightingStyleValid = (classId: ClassId, styleId: string) =>
+  getFightingStyleOptions(classId).some((option) => option.id === styleId)

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -6,8 +6,6 @@ export type AbilityScoreKey =
   | "wisdom"
   | "charisma"
 
-export type AbilityScores = Record<AbilityScoreKey, number>
-
 export const abilityScoreKeys: AbilityScoreKey[] = [
   "strength",
   "dexterity",
@@ -26,9 +24,53 @@ export const abilityScoreLabels: Record<AbilityScoreKey, string> = {
   charisma: "Charisma",
 }
 
+export type AbilityScores = Record<AbilityScoreKey, number>
+
 export const abilityScoreDefaultValue = 10
 
 export const defaultDiceExpression = "4d6"
+
+export const classIds = [
+  "barbarian",
+  "bard",
+  "cleric",
+  "druid",
+  "fighter",
+  "monk",
+  "paladin",
+  "ranger",
+  "rogue",
+  "sorcerer",
+  "warlock",
+  "wizard",
+] as const
+
+export type ClassId = (typeof classIds)[number]
+
+export interface ClassOption {
+  id: ClassId
+  label: string
+}
+
+export interface SubclassOption {
+  id: string
+  label: string
+  description?: string
+}
+
+export type SpellcastingStyle = "prepared" | "spells_known" | "pact"
+
+export interface SpellcastingMeta {
+  style: SpellcastingStyle
+  focus?: string
+  preparationLabel?: string
+}
+
+export interface FightingStyleOption {
+  id: string
+  label: string
+  description?: string
+}
 
 export type DiceMethodId =
   | "custom_expression"


### PR DESCRIPTION
## Summary
- add SRD-friendly class metadata with helpers and extend the character schema/defaults to include class selection
- build a ClassSelectionSection UI, integrate it into App.tsx, and surface class-aware ability hints and combat defaults
- refresh combat guidance, styling, and docs to cover the new class workflow and manual testing steps

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e550f43ec483298b1d5e4bad028250