### PR TITLE
ci: fix GitHub Pages workflow configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Configure Pages
+        id: pages
+        uses: actions/configure-pages@v5
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -46,3 +49,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          token: ${{ github.token }}


### PR DESCRIPTION
## Summary
- configure the GitHub Pages workflow before building so Actions prepares the deployment environment
- pass the GitHub token to the deploy step to ensure the site publishes to the pages environment

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e55ba45e508329ab43d80450f7f73c