### PR TITLE
Fix dice expression validation for zero digits

### DIFF
--- a/src/lib/dice.ts
+++ b/src/lib/dice.ts
@@ -102,11 +102,11 @@ export const parseDiceExpression = (expression: string): ParsedDiceExpression | 
       const countValue = diceMatch[1]
       const sidesValue = diceMatch[2]
 
-      // Additional validation: reject leading zeros
-      if (countValue && (countValue.startsWith('0') || countValue.includes('0') && countValue.length > 1)) {
+      // Additional validation: reject values with leading zeros (e.g. 01d6)
+      if (countValue && countValue.length > 1 && countValue.startsWith("0")) {
         return null
       }
-      if (sidesValue.startsWith('0') || (sidesValue.includes('0') && sidesValue.length > 1)) {
+      if (sidesValue.length > 1 && sidesValue.startsWith("0")) {
         return null
       }
 


### PR DESCRIPTION
## Summary
- adjust dice expression parser to only reject values with leading zeros
- allow dice counts and sides such as 1d10 or 2d20 to pass validation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e55ba45e508329ab43d80450f7f73c