### PR TITLE
feat: apply racial bonuses and traits

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -267,6 +267,43 @@
   color: #6f5e4b;
 }
 
+.race-summary {
+  display: grid;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+}
+
+.race-summary__traits {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.race-summary__trait-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.3rem;
+  color: #564731;
+}
+
+.race-summary__trait-name {
+  font-weight: 600;
+  color: #3d3326;
+}
+
+.race-summary__trait-description {
+  color: #5c4f3d;
+}
+
+.scores-note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #4f3c61;
+  background: rgba(97, 61, 193, 0.08);
+  border-radius: 10px;
+  padding: 0.6rem 0.8rem;
+}
+
 .option-stack {
   display: grid;
   gap: 0.75rem;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import {
   isDiceExpressionValid,
   rollAbilityScores,
 } from "./lib/dice"
+import { applyRaceBonuses, getRaceDefinition } from "./lib/races"
 import {
   formatSavingThrows,
   getClassDefaults,
@@ -71,6 +72,7 @@ function App() {
   const abilityScores = watch("abilityScores")
   const classSelection = watch("classSelection")
   const level = watch("identity.level") ?? defaultCharacterIdentity.level
+  const ancestry = watch("identity.ancestry")
   const selectedMethod = useMemo(() => getDiceMethod(methodId), [methodId])
   const classDefaults = useMemo(() => {
     if (!classSelection) {
@@ -86,6 +88,13 @@ function App() {
 
     return getClassDefinition(classSelection.classId)
   }, [classSelection])
+
+  const selectedRace = useMemo(() => getRaceDefinition(ancestry), [ancestry])
+
+  const adjustedAbilityScores = useMemo(
+    () => applyRaceBonuses(abilityScores, ancestry),
+    [abilityScores, ancestry],
+  )
 
   const expressionRegister = register("diceExpression", {
     onChange: () => {
@@ -223,9 +232,15 @@ function App() {
             <p>Values generated from your chosen method. Edit them once the full sheet is live.</p>
           </header>
 
+          {selectedRace && (
+            <p className="scores-note">
+              Racial bonuses from the {selectedRace.label} ancestry are applied to these totals.
+            </p>
+          )}
+
           <div className="scores-grid">
             {abilityScoreKeys.map((key) => {
-              const score = abilityScores?.[key] ?? abilityScoreDefaultValue
+              const score = adjustedAbilityScores?.[key] ?? abilityScoreDefaultValue
               const modifier = abilityMod(score)
 
               return (

--- a/src/components/CharacterIdentitySection.tsx
+++ b/src/components/CharacterIdentitySection.tsx
@@ -1,21 +1,13 @@
-import { useFormContext } from "react-hook-form"
+import { useFormContext, useWatch } from "react-hook-form"
 import {
   alignmentOptions,
   type CharacterFormInput,
 } from "../schema/character"
-
-const ancestrySuggestions = [
-  "Human",
-  "Elf",
-  "Half-Elf",
-  "Dwarf",
-  "Halfling",
-  "Gnome",
-  "Tiefling",
-  "Dragonborn",
-  "Half-Orc",
-  "Goliath",
-]
+import {
+  getRaceAbilityBonuses,
+  getRaceDefinition,
+  races,
+} from "../lib/races"
 
 const backgroundSuggestions = [
   "Acolyte",
@@ -35,6 +27,11 @@ export const CharacterIdentitySection = () => {
     register,
     formState: { errors },
   } = useFormContext<CharacterFormInput>()
+  const selectedAncestry = useWatch<CharacterFormInput, "identity.ancestry">({
+    name: "identity.ancestry",
+  })
+  const selectedRace = getRaceDefinition(selectedAncestry)
+  const abilityBonuses = getRaceAbilityBonuses(selectedRace)
 
   type IdentityField = keyof CharacterFormInput["identity"]
   const identityErrors = errors.identity as
@@ -79,20 +76,45 @@ export const CharacterIdentitySection = () => {
 
         <div className="field">
           <label htmlFor="ancestry">Ancestry</label>
-          <input
-            id="ancestry"
-            type="text"
-            list="character-ancestry"
-            placeholder="Half-Elf"
-            {...register("identity.ancestry")}
-          />
-          <datalist id="character-ancestry">
-            {ancestrySuggestions.map((ancestry) => (
-              <option key={ancestry} value={ancestry} />
+          <select id="ancestry" {...register("identity.ancestry")}>
+            {races.map((race) => (
+              <option key={race.id} value={race.id}>
+                {race.label}
+              </option>
             ))}
-          </datalist>
+          </select>
           {getError("ancestry") && (
             <p className="field__error">{getError("ancestry")}</p>
+          )}
+          {selectedRace && (
+            <div className="race-summary">
+              <p className="field__description">
+                <strong>Speed:</strong> {selectedRace.speed} ft.
+              </p>
+              {abilityBonuses.length > 0 && (
+                <p className="field__description">
+                  <strong>Ability bonuses:</strong>{" "}
+                  {abilityBonuses
+                    .map((bonus) => `${bonus.amount > 0 ? "+" : ""}${bonus.amount} ${bonus.ability}`)
+                    .join(", ")}
+                </p>
+              )}
+              {selectedRace.abilities.length > 0 && (
+                <div className="race-summary__traits">
+                  <p className="field__description">
+                    <strong>Traits</strong>
+                  </p>
+                  <ul className="race-summary__trait-list">
+                    {selectedRace.abilities.map((trait) => (
+                      <li key={trait.name}>
+                        <span className="race-summary__trait-name">{trait.name}.</span>{" "}
+                        <span className="race-summary__trait-description">{trait.description}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
           )}
         </div>
 

--- a/src/lib/races.ts
+++ b/src/lib/races.ts
@@ -1,0 +1,202 @@
+import {
+  abilityScoreDefaultValue,
+  abilityScoreKeys,
+  abilityScoreLabels,
+  type AbilityScores,
+  type AbilityScoreKey,
+  type RaceDefinition,
+  type RaceId,
+  raceIds,
+} from "../types/character"
+
+const createDefinition = (definition: RaceDefinition): RaceDefinition => definition
+
+const raceDefinitionMap: Record<RaceId, RaceDefinition> = {
+  human: createDefinition({
+    id: "human",
+    label: "Human",
+    speed: 30,
+    abilityBonuses: abilityScoreKeys.reduce<Partial<Record<AbilityScoreKey, number>>>(
+      (acc, key) => {
+        acc[key] = 1
+        return acc
+      },
+      {},
+    ),
+    abilities: [
+      {
+        name: "Versatile",
+        description: "Humans excel at adapting to challenges, gaining proficiency in one additional skill of your choice.",
+      },
+      {
+        name: "Ambition",
+        description: "Gain one extra talent or feat whenever the campaign awards feats for advancement.",
+      },
+    ],
+  }),
+  dwarf: createDefinition({
+    id: "dwarf",
+    label: "Dwarf",
+    speed: 25,
+    abilityBonuses: {
+      constitution: 2,
+      wisdom: 1,
+    },
+    abilities: [
+      {
+        name: "Dwarven Resilience",
+        description: "Advantage on saving throws against poison and resistance to poison damage.",
+      },
+      {
+        name: "Stonecunning",
+        description: "Double your proficiency bonus on History checks related to stonework.",
+      },
+    ],
+  }),
+  half_orc: createDefinition({
+    id: "half_orc",
+    label: "Half-Orc",
+    speed: 30,
+    abilityBonuses: {
+      strength: 2,
+      constitution: 1,
+    },
+    abilities: [
+      {
+        name: "Relentless Endurance",
+        description: "When reduced to 0 hit points, drop to 1 hit point instead (once per long rest).",
+      },
+      {
+        name: "Savage Attacks",
+        description: "Add an extra weapon damage die when you score a critical hit with a melee attack.",
+      },
+    ],
+  }),
+  elf: createDefinition({
+    id: "elf",
+    label: "Elf",
+    speed: 30,
+    abilityBonuses: {
+      dexterity: 2,
+      intelligence: 1,
+    },
+    abilities: [
+      {
+        name: "Fey Ancestry",
+        description: "Advantage on saving throws against being charmed, and magic can’t put you to sleep.",
+      },
+      {
+        name: "Keen Senses",
+        description: "Proficiency in the Perception skill.",
+      },
+    ],
+  }),
+  half_elf: createDefinition({
+    id: "half_elf",
+    label: "Half-Elf",
+    speed: 30,
+    abilityBonuses: {
+      charisma: 2,
+      dexterity: 1,
+      wisdom: 1,
+    },
+    abilities: [
+      {
+        name: "Dual Heritage",
+        description: "Gain proficiency in two skills of your choice.",
+      },
+      {
+        name: "Fey Ancestry",
+        description: "Advantage on saving throws against being charmed, and magic can’t put you to sleep.",
+      },
+    ],
+  }),
+  gnome: createDefinition({
+    id: "gnome",
+    label: "Gnome",
+    speed: 25,
+    abilityBonuses: {
+      intelligence: 2,
+      dexterity: 1,
+    },
+    abilities: [
+      {
+        name: "Gnome Cunning",
+        description: "Advantage on all Intelligence, Wisdom, and Charisma saving throws against magic.",
+      },
+      {
+        name: "Tinker",
+        description: "You can construct tiny clockwork devices given an hour and appropriate materials.",
+      },
+    ],
+  }),
+  lizard_man: createDefinition({
+    id: "lizard_man",
+    label: "Lizard-Man",
+    speed: 30,
+    abilityBonuses: {
+      constitution: 2,
+      wisdom: 1,
+    },
+    abilities: [
+      {
+        name: "Aquatic Adaptation",
+        description: "You can hold your breath for up to 15 minutes and have a swimming speed equal to your walking speed.",
+      },
+      {
+        name: "Natural Armor",
+        description: "When unarmored, your base AC is 13 + your Dexterity modifier.",
+      },
+    ],
+  }),
+}
+
+export const races: RaceDefinition[] = raceIds.map((id) => raceDefinitionMap[id])
+
+export const getRaceDefinition = (id: RaceId | null | undefined): RaceDefinition | null => {
+  if (!id) {
+    return null
+  }
+
+  return raceDefinitionMap[id]
+}
+
+export interface RaceAbilityBonus {
+  ability: string
+  amount: number
+}
+
+export const getRaceAbilityBonuses = (
+  race: RaceDefinition | null,
+): RaceAbilityBonus[] => {
+  if (!race) {
+    return []
+  }
+
+  return abilityScoreKeys
+    .map((key) => {
+      const amount = race.abilityBonuses[key] ?? 0
+      return {
+        ability: abilityScoreLabels[key],
+        amount,
+      }
+    })
+    .filter((entry) => entry.amount !== 0)
+}
+
+export const applyRaceBonuses = (
+  baseScores: AbilityScores | null | undefined,
+  raceId: RaceId | null | undefined,
+): AbilityScores => {
+  const race = getRaceDefinition(raceId)
+  const base = abilityScoreKeys.reduce<AbilityScores>((acc, key) => {
+    const fallback = baseScores?.[key] ?? abilityScoreDefaultValue
+    acc[key] = fallback
+    if (race) {
+      acc[key] += race.abilityBonuses[key] ?? 0
+    }
+    return acc
+  }, {} as AbilityScores)
+
+  return base
+}

--- a/src/schema/character.ts
+++ b/src/schema/character.ts
@@ -4,6 +4,8 @@ import {
   abilityScoreKeys,
   classIds,
   defaultDiceExpression,
+  raceIds,
+  type RaceId,
   type AbilityScores,
   type ClassId,
   type CombatStats,
@@ -55,7 +57,7 @@ export const characterIdentitySchema = z.object({
     .int()
     .min(1, "Minimum level is 1")
     .max(20, "Maximum adventuring level is 20"),
-  ancestry: z.string().min(1, "Ancestry is required"),
+  ancestry: z.enum(raceIds),
   background: z.string().min(1, "Background is required"),
   alignment: z.enum(alignmentOptions),
   playerName: z.string().min(1, "Player name is required"),
@@ -217,11 +219,12 @@ export type CharacterCombat = CharacterFormValues["combat"]
 
 const DEFAULT_LEVEL = 1
 const DEFAULT_CLASS_ID: ClassId = "fighter"
+const DEFAULT_RACE_ID: RaceId = "human"
 
 export const defaultCharacterIdentity: CharacterIdentity = {
   characterName: "",
   level: DEFAULT_LEVEL,
-  ancestry: "",
+  ancestry: DEFAULT_RACE_ID,
   background: "",
   alignment: "Unaligned",
   playerName: "",

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -30,6 +30,31 @@ export const abilityScoreDefaultValue = 10
 
 export const defaultDiceExpression = "4d6"
 
+export const raceIds = [
+  "human",
+  "dwarf",
+  "half_orc",
+  "elf",
+  "half_elf",
+  "gnome",
+  "lizard_man",
+] as const
+
+export type RaceId = (typeof raceIds)[number]
+
+export interface RaceAbility {
+  name: string
+  description: string
+}
+
+export interface RaceDefinition {
+  id: RaceId
+  label: string
+  speed: number
+  abilityBonuses: Partial<Record<AbilityScoreKey, number>>
+  abilities: RaceAbility[]
+}
+
 export const classIds = [
   "barbarian",
   "bard",


### PR DESCRIPTION
## Summary
- add typed race definitions including ability bonuses, traits, and speeds
- switch the ancestry picker to a race selector with contextual ability and trait summaries
- apply racial bonuses to displayed ability scores and style the new ancestry insights

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e99f391a28832982449ec0229e319c