### PR TITLE
fix: use svg portrait placeholders

### DIFF
--- a/docs/character-portrait-plan.md
+++ b/docs/character-portrait-plan.md
@@ -7,7 +7,7 @@
 ## Assumptions
 - Character gender will be captured as a limited enum (e.g., `"female" | "male" | "nonbinary" | "custom"`) with optional custom text for edge cases.
 - Portraits will live in `public/portraits/` so they can be referenced via simple URLs without going through the bundler.
-- Each portrait variant follows a predictable file naming convention: `<ancestry>__<class>__<gender>.webp` with lowercase, kebab-case identifiers that align with our existing enums.
+- Each portrait variant follows a predictable file naming convention: `<ancestry>__<class>__<gender>.svg` with lowercase, kebab-case identifiers that align with our existing enums.
 - When an exact match is missing we can fall back in order: full triple → ancestry+gender → class+gender → ancestry only → global default.
 
 ## Workstreams
@@ -36,7 +36,7 @@
 ### 4. Asset Management
 1. Add a handful of starter portrait images to `public/portraits/` that cover representative combinations (ensure we have at least one fallback per ancestry and class group).
 2. Document the naming scheme inside `docs/development.md` so contributors can drop in additional variants without code changes.
-3. Consider introducing `public/portraits/fallback.webp` as the universal default referenced by `resolvePortraitSource`.
+3. Consider introducing `public/portraits/fallback.svg` as the universal default referenced by `resolvePortraitSource`.
 
 ### 5. Styling & Accessibility
 1. Add portrait-specific styles to `App.css` (e.g., max-width, aspect ratio, shadow) while keeping overrides minimal.

--- a/docs/development.md
+++ b/docs/development.md
@@ -38,6 +38,13 @@ Automated testing is not yet configured; rely on the following manual checks:
    - Switch to a prepared caster (Cleric, Druid, Wizard) and confirm the prepared-spell checkbox toggles without leaking to non-prepared classes.
    - Apply class defaults from the combat panel and verify hit dice / max HP update without overwriting custom current HP unless needed.
 5. Adjust combat fields (AC, HP, speed) to ensure min/max limits and HP > Max validation behave as expected.
+6. Verify the character portrait updates as ancestry, class, and gender selections change. Confirm the fallback image appears for unsupported combinations and that the layout stays responsive on narrow viewports.
+
+## Portrait Assets
+
+- Store portrait art in `public/portraits/` using the naming scheme `<ancestry>__<class>__<gender>.svg` (lowercase, kebab-case identifiers aligned with the schema enums). Partial fallbacks may omit class or gender segments (e.g. `dwarf.svg`, `fighter__male.svg`).
+- Prefer lightweight SVG illustrations or other text-based formats so pull requests avoid binary asset diffs. If you must commit raster art, keep the file under version control through Git LFS.
+- Run `npm run build` after adding art to ensure Vite picks up the new static files, and add a manifest entry in `src/lib/portraits.ts` so the resolver can find the asset.
 
 Additions to the dice parser or schema should include unit coverage (e.g., Vitest) in future iterations; see `docs/status.md` for current testing roadmap.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -18,6 +18,7 @@
 - Adjusted GitHub Pages workflow triggers so deployments run from `main` or the legacy `master` branch.
 - Delivered class selection flow with SRD class metadata, subclass enforcement, fighting style radios, and prepared-spell toggle backed by new `lib/classes.ts` helpers.
 - Surfaced class-derived defaults in the combat panel, including an "apply defaults" action and ability-focused copy in the ability roller.
+- Implemented an ancestry/class/gender-aware portrait system with resolver fallbacks, loading skeleton, and starter assets.
 
 ## In Progress / Needs Attention
 
@@ -38,5 +39,7 @@
 - Should ability scores remain read-only derived values, or will manual overrides be allowed per house rules?
 - What level of spell management is expected (full spellbook vs. quick summary)?
 - Are there external data integrations planned (SRD APIs, compendium imports)?
+- Should players be able to override the auto-selected portrait with manual picks or uploads?
+- Do we need animated or multi-frame portrait support for future theming?
 
 Capture answers or new tasks here before closing any future work sessions.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test": "vitest run",
     "deploy": "npm run build && gh-pages -d dist"
   },
   "dependencies": {
@@ -30,6 +31,7 @@
     "globals": "^16.4.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.45.0",
-    "vite": "^7.1.7"
+    "vite": "^7.1.7",
+    "vitest": "^2.1.5"
   }
 }

--- a/public/portraits/dwarf.svg
+++ b/public/portraits/dwarf.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 420" role="img" aria-labelledby="title desc">
+  <title id="title">Dwarf Adventurer Portrait</title>
+  <desc id="desc">Stylised bust of a dwarf with a braided beard motif.</desc>
+  <defs>
+    <linearGradient id="dwarf-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#9f7aea" />
+      <stop offset="100%" stop-color="#553c9a" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="420" rx="24" fill="url(#dwarf-bg)" />
+  <g fill="none" stroke="#fbd38d" stroke-width="6" stroke-linecap="round">
+    <path d="M220 170c0 40-26 70-60 70s-60-30-60-70 26-70 60-70 60 30 60 70z" />
+    <path d="M90 308c12-38 41-64 70-64s58 26 70 64" />
+    <path d="M140 256c6 22 14 36 20 36s14-14 20-36" />
+  </g>
+  <text x="160" y="360" text-anchor="middle" font-family="'Trebuchet MS', sans-serif" font-size="28" fill="#faf089" letter-spacing="1.4">
+    Dwarf
+  </text>
+</svg>

--- a/public/portraits/elf__wizard__male.svg
+++ b/public/portraits/elf__wizard__male.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 420" role="img" aria-labelledby="title desc">
+  <title id="title">Elf Man Wizard Portrait</title>
+  <desc id="desc">Stylised bust of an elven wizard with arcane motifs.</desc>
+  <defs>
+    <linearGradient id="elf-wizard-male-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#68d391" />
+      <stop offset="100%" stop-color="#2f855a" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="420" rx="24" fill="url(#elf-wizard-male-bg)" />
+  <g fill="none" stroke="#1c4532" stroke-width="6" stroke-linecap="round">
+    <path d="M214 162c0 36-24 64-54 64s-54-28-54-64 24-64 54-64 54 28 54 64z" />
+    <path d="M98 300c12-46 36-70 62-70s50 24 62 70" />
+    <path d="M116 222c12-18 28-28 44-28s32 10 44 28" />
+    <path d="M160 236l-20 28h40z" />
+  </g>
+  <text x="160" y="360" text-anchor="middle" font-family="'Trebuchet MS', sans-serif" font-size="24" fill="#1c4532" letter-spacing="1.2">
+    Elf • Wizard
+  </text>
+</svg>

--- a/public/portraits/fallback.svg
+++ b/public/portraits/fallback.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 420" role="img" aria-labelledby="title desc">
+  <title id="title">Adventurer Portrait Placeholder</title>
+  <desc id="desc">A stylised placeholder illustration used when no portrait art is available.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4a5568" />
+      <stop offset="100%" stop-color="#2d3748" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="420" rx="24" fill="url(#bg)" />
+  <g fill="none" stroke="#a0aec0" stroke-width="6" stroke-linecap="round">
+    <path d="M101 146c0-33 26-60 59-60s59 27 59 60-26 60-59 60-59-27-59-60z" />
+    <path d="M72 312c8-48 45-84 88-84s80 36 88 84" />
+  </g>
+  <text x="160" y="360" text-anchor="middle" font-family="'Trebuchet MS', sans-serif" font-size="28" fill="#e2e8f0" letter-spacing="1.5">
+    Adventurer
+  </text>
+</svg>

--- a/public/portraits/fighter__male.svg
+++ b/public/portraits/fighter__male.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 420" role="img" aria-labelledby="title desc">
+  <title id="title">Man Fighter Portrait</title>
+  <desc id="desc">Stylised bust of a masculine fighter with shield motifs.</desc>
+  <defs>
+    <linearGradient id="fighter-male-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fed7d7" />
+      <stop offset="100%" stop-color="#c53030" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="420" rx="24" fill="url(#fighter-male-bg)" />
+  <g fill="none" stroke="#742a2a" stroke-width="6" stroke-linecap="round">
+    <path d="M210 170c0 34-25 62-56 62s-56-28-56-62 25-62 56-62 56 28 56 62z" />
+    <path d="M94 300c10-40 38-62 60-62s50 22 60 62" />
+    <path d="M112 236l32-24 32 24" />
+    <circle cx="160" cy="264" r="22" />
+  </g>
+  <text x="160" y="360" text-anchor="middle" font-family="'Trebuchet MS', sans-serif" font-size="24" fill="#742a2a" letter-spacing="1.6">
+    Fighter
+  </text>
+</svg>

--- a/public/portraits/human.svg
+++ b/public/portraits/human.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 420" role="img" aria-labelledby="title desc">
+  <title id="title">Human Adventurer Portrait</title>
+  <desc id="desc">Stylised bust of a human character with a warm color palette.</desc>
+  <defs>
+    <linearGradient id="human-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f6ad55" />
+      <stop offset="100%" stop-color="#dd6b20" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="420" rx="24" fill="url(#human-bg)" />
+  <g fill="none" stroke="#2d3748" stroke-width="6" stroke-linecap="round">
+    <path d="M210 168c0 34-26 62-58 62s-58-28-58-62 26-62 58-62 58 28 58 62z" />
+    <path d="M90 302c12-42 39-70 62-70s50 28 62 70" />
+  </g>
+  <text x="160" y="360" text-anchor="middle" font-family="'Trebuchet MS', sans-serif" font-size="28" fill="#1a202c" letter-spacing="1.2">
+    Human
+  </text>
+</svg>

--- a/public/portraits/human__female.svg
+++ b/public/portraits/human__female.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 420" role="img" aria-labelledby="title desc">
+  <title id="title">Human Woman Adventurer Portrait</title>
+  <desc id="desc">Stylised bust of a human woman wearing a cloak.</desc>
+  <defs>
+    <linearGradient id="human-female-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fbb6ce" />
+      <stop offset="100%" stop-color="#d53f8c" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="420" rx="24" fill="url(#human-female-bg)" />
+  <g fill="none" stroke="#fff5f7" stroke-width="6" stroke-linecap="round">
+    <path d="M212 166c0 36-25 64-56 64s-56-28-56-64 25-64 56-64 56 28 56 64z" />
+    <path d="M92 296c10-36 36-58 64-58s54 22 64 58" />
+    <path d="M122 216c12 10 24 16 38 16s26-6 38-16" />
+  </g>
+  <text x="160" y="360" text-anchor="middle" font-family="'Trebuchet MS', sans-serif" font-size="26" fill="#fff5f7" letter-spacing="1.4">
+    Human • Woman
+  </text>
+</svg>

--- a/public/portraits/human__fighter__female.svg
+++ b/public/portraits/human__fighter__female.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 420" role="img" aria-labelledby="title desc">
+  <title id="title">Human Woman Fighter Portrait</title>
+  <desc id="desc">Stylised bust of a human fighter in plate armour.</desc>
+  <defs>
+    <linearGradient id="human-fighter-female-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#63b3ed" />
+      <stop offset="100%" stop-color="#2b6cb0" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="420" rx="24" fill="url(#human-fighter-female-bg)" />
+  <g fill="none" stroke="#edf2f7" stroke-width="6" stroke-linecap="round">
+    <path d="M212 170c0 36-26 64-58 64s-58-28-58-64 26-64 58-64 58 28 58 64z" />
+    <path d="M96 298c10-40 38-62 58-62s48 22 58 62" />
+    <path d="M128 228l32-32 32 32" />
+    <path d="M144 248l16 48 16-48" />
+  </g>
+  <text x="160" y="360" text-anchor="middle" font-family="'Trebuchet MS', sans-serif" font-size="24" fill="#ebf8ff" letter-spacing="1.4">
+    Human • Fighter
+  </text>
+</svg>

--- a/src/App.css
+++ b/src/App.css
@@ -11,6 +11,83 @@
   align-items: flex-start;
 }
 
+.hero-header {
+  display: flex;
+  justify-content: center;
+  background: radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.9), rgba(255, 253, 247, 0.75));
+}
+
+.character-portrait {
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+  justify-items: center;
+}
+
+.character-portrait__frame {
+  width: min(280px, 100%);
+  aspect-ratio: 3 / 4;
+  border-radius: 20px;
+  overflow: hidden;
+  position: relative;
+  background: linear-gradient(135deg, rgba(157, 110, 80, 0.18), rgba(52, 29, 15, 0.08));
+  box-shadow: 0 20px 48px rgba(44, 35, 27, 0.22);
+  isolation: isolate;
+}
+
+.character-portrait__frame::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.character-portrait__placeholder {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 242, 220, 0.9), rgba(232, 212, 184, 0.65));
+  animation: portraitPulse 1.6s ease-in-out infinite;
+}
+
+.character-portrait__image {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0;
+  transition: opacity 240ms ease;
+}
+
+.character-portrait__frame--loaded .character-portrait__placeholder {
+  opacity: 0;
+  transition: opacity 220ms ease;
+}
+
+.character-portrait__frame--loaded .character-portrait__image {
+  opacity: 1;
+}
+
+.character-portrait__attribution {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #5c4f3d;
+  text-align: center;
+}
+
+@keyframes portraitPulse {
+  0%,
+  100% {
+    opacity: 0.75;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
 .panel {
   background: rgba(255, 253, 250, 0.98);
   border: 1px solid #dccab6;

--- a/src/components/CharacterIdentitySection.tsx
+++ b/src/components/CharacterIdentitySection.tsx
@@ -8,6 +8,11 @@ import {
   getRaceDefinition,
   races,
 } from "../lib/races"
+import {
+  genderOptions,
+  genderLabels,
+  type GenderId,
+} from "../types/character"
 
 const backgroundSuggestions = [
   "Acolyte",
@@ -30,8 +35,12 @@ export const CharacterIdentitySection = () => {
   const selectedAncestry = useWatch<CharacterFormInput, "identity.ancestry">({
     name: "identity.ancestry",
   })
+  const selectedGenderId = useWatch<CharacterFormInput, "identity.genderId">({
+    name: "identity.genderId",
+  })
   const selectedRace = getRaceDefinition(selectedAncestry)
   const abilityBonuses = getRaceAbilityBonuses(selectedRace)
+  const isCustomGender = selectedGenderId === "custom"
 
   type IdentityField = keyof CharacterFormInput["identity"]
   const identityErrors = errors.identity as
@@ -119,6 +128,25 @@ export const CharacterIdentitySection = () => {
         </div>
 
         <div className="field">
+          <label htmlFor="gender">Gender</label>
+          <select id="gender" {...register("identity.genderId")}> 
+            {genderOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          {getError("genderId") && (
+            <p className="field__error">{getError("genderId")}</p>
+          )}
+          {selectedGenderId && selectedGenderId !== "custom" && (
+            <p className="field__description">
+              Displayed as {genderLabels[selectedGenderId as Exclude<GenderId, "custom">]}
+            </p>
+          )}
+        </div>
+
+        <div className="field">
           <label htmlFor="background">Background</label>
           <input
             id="background"
@@ -150,6 +178,21 @@ export const CharacterIdentitySection = () => {
             <p className="field__error">{getError("alignment")}</p>
           )}
         </div>
+
+        {isCustomGender && (
+          <div className="field field--span-2">
+            <label htmlFor="custom-gender">Custom gender label</label>
+            <input
+              id="custom-gender"
+              type="text"
+              placeholder="Genderfluid guardian"
+              {...register("identity.customGenderLabel", { shouldUnregister: true })}
+            />
+            {getError("customGenderLabel") && (
+              <p className="field__error">{getError("customGenderLabel")}</p>
+            )}
+          </div>
+        )}
 
         <div className="field field--span-2">
           <label htmlFor="player-name">Player</label>

--- a/src/components/CharacterPortrait.tsx
+++ b/src/components/CharacterPortrait.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useMemo, useState } from "react"
+import type { PortraitSource } from "../lib/portraits"
+
+interface CharacterPortraitProps {
+  source: PortraitSource
+  ancestryLabel?: string | null
+  classLabel?: string | null
+  genderLabel?: string | null
+}
+
+const createAltText = (
+  genderLabel?: string | null,
+  ancestryLabel?: string | null,
+  classLabel?: string | null,
+) => {
+  const segments = [genderLabel, ancestryLabel, classLabel].filter(
+    (segment): segment is string => Boolean(segment && segment.trim()),
+  )
+
+  if (segments.length === 0) {
+    return "Portrait of an adventurer"
+  }
+
+  const description = segments
+    .map((segment, index) => (index === 0 ? segment : segment.toLowerCase()))
+    .join(" ")
+
+  return `Portrait of a ${description}`
+}
+
+export const CharacterPortrait = ({
+  source,
+  ancestryLabel,
+  classLabel,
+  genderLabel,
+}: CharacterPortraitProps) => {
+  const [isLoaded, setIsLoaded] = useState(false)
+
+  useEffect(() => {
+    setIsLoaded(false)
+  }, [source.src])
+
+  const altText = useMemo(
+    () => createAltText(genderLabel, ancestryLabel, classLabel),
+    [ancestryLabel, classLabel, genderLabel],
+  )
+
+  return (
+    <figure className="character-portrait" aria-live="polite">
+      <div
+        className={`character-portrait__frame${
+          isLoaded ? " character-portrait__frame--loaded" : ""
+        }`}
+      >
+        {!isLoaded && (
+          <div className="character-portrait__placeholder" aria-hidden="true" />
+        )}
+        <img
+          key={source.src}
+          className="character-portrait__image"
+          src={source.src}
+          alt={altText}
+          role="img"
+          loading="lazy"
+          onLoad={() => setIsLoaded(true)}
+          onError={() => setIsLoaded(true)}
+        />
+      </div>
+      {source.attribution && (
+        <figcaption className="character-portrait__attribution">
+          {source.attribution}
+        </figcaption>
+      )}
+    </figure>
+  )
+}

--- a/src/lib/portraits.test.ts
+++ b/src/lib/portraits.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest"
+import { resolvePortraitSource, PORTRAIT_MANIFEST } from "./portraits"
+import { createPortraitId } from "../types/character"
+
+describe("resolvePortraitSource", () => {
+  it("returns the exact portrait match when all identifiers align", () => {
+    const source = resolvePortraitSource(
+      createPortraitId("human", "fighter", "female"),
+    )
+
+    expect(source).toEqual(PORTRAIT_MANIFEST["human__fighter__female"])
+  })
+
+  it("falls back to an ancestry + gender portrait when class is missing", () => {
+    const source = resolvePortraitSource(
+      createPortraitId("human", "wizard", "female"),
+    )
+
+    expect(source).toEqual(PORTRAIT_MANIFEST["human__female"])
+  })
+
+  it("uses the class + gender portrait when ancestry specific art is unavailable", () => {
+    const source = resolvePortraitSource(
+      createPortraitId("gnome", "fighter", "male"),
+    )
+
+    expect(source).toEqual(PORTRAIT_MANIFEST["fighter__male"])
+  })
+
+  it("resolves to an ancestry-only fallback when gendered assets are missing", () => {
+    const source = resolvePortraitSource(
+      createPortraitId("dwarf", "bard", "nonbinary"),
+    )
+
+    expect(source).toEqual(PORTRAIT_MANIFEST.dwarf)
+  })
+
+  it("returns the global fallback when no portrait variants are configured", () => {
+    const source = resolvePortraitSource(
+      createPortraitId("lizard_man", "bard", "nonbinary"),
+    )
+
+    expect(source).toEqual(PORTRAIT_MANIFEST.fallback)
+  })
+
+  it("treats custom genders as unassigned for portrait lookup", () => {
+    const source = resolvePortraitSource(
+      createPortraitId("human", "fighter", "custom"),
+    )
+
+    expect(source).toEqual(PORTRAIT_MANIFEST.human)
+  })
+
+  it("supports ancestry identifiers containing underscores", () => {
+    PORTRAIT_MANIFEST["half_orc"] = { src: "/portraits/half_orc.svg" }
+
+    try {
+      const source = resolvePortraitSource(
+        createPortraitId("half_orc", "bard", null),
+      )
+
+      expect(source).toEqual(PORTRAIT_MANIFEST["half_orc"])
+    } finally {
+      delete PORTRAIT_MANIFEST["half_orc"]
+    }
+  })
+
+  it("falls back to a class portrait when ancestry art is unavailable", () => {
+    PORTRAIT_MANIFEST.fighter = { src: "/portraits/fighter__male.svg" }
+
+    try {
+      const source = resolvePortraitSource(createPortraitId(null, "fighter", null))
+
+      expect(source).toEqual(PORTRAIT_MANIFEST.fighter)
+    } finally {
+      delete PORTRAIT_MANIFEST.fighter
+    }
+  })
+})

--- a/src/lib/portraits.ts
+++ b/src/lib/portraits.ts
@@ -1,0 +1,75 @@
+import { createPortraitId, type PortraitId } from "../types/character"
+
+export interface PortraitVariant {
+  src: string
+  attribution?: string
+}
+
+export type PortraitSource = PortraitVariant
+
+type PortraitManifest = Record<string, PortraitVariant>
+
+const FALLBACK_KEY = "fallback"
+
+const sanitizeSegment = (segment: string | null | undefined) => {
+  if (!segment) {
+    return null
+  }
+
+  return segment.trim().toLowerCase().replace(/\s+/g, "_")
+}
+
+export const PORTRAIT_MANIFEST: PortraitManifest = {
+  [FALLBACK_KEY]: { src: "/portraits/fallback.svg" },
+  "human__fighter__female": { src: "/portraits/human__fighter__female.svg" },
+  "human__female": { src: "/portraits/human__female.svg" },
+  "fighter__male": { src: "/portraits/fighter__male.svg" },
+  "elf__wizard__male": { src: "/portraits/elf__wizard__male.svg" },
+  human: { src: "/portraits/human.svg" },
+  dwarf: { src: "/portraits/dwarf.svg" },
+}
+
+const getManifestEntry = (key: string | null) => {
+  if (!key) {
+    return undefined
+  }
+
+  return PORTRAIT_MANIFEST[key]
+}
+
+export const resolvePortraitSource = ({
+  ancestry,
+  classId,
+  genderId,
+}: PortraitId): PortraitSource => {
+  const ancestrySegment = sanitizeSegment(ancestry ?? null)
+  const classSegment = sanitizeSegment(classId ?? null)
+  const genderSegment = sanitizeSegment(
+    genderId && genderId !== "custom" ? genderId : null,
+  )
+
+  const portraitKeyPriority = [
+    genderSegment && ancestrySegment && classSegment
+      ? `${ancestrySegment}__${classSegment}__${genderSegment}`
+      : null,
+    genderSegment && ancestrySegment ? `${ancestrySegment}__${genderSegment}` : null,
+    genderSegment && classSegment ? `${classSegment}__${genderSegment}` : null,
+    ancestrySegment,
+    classSegment,
+  ]
+
+  for (const key of portraitKeyPriority) {
+    const entry = getManifestEntry(key)
+    if (entry) {
+      return entry
+    }
+  }
+
+  return PORTRAIT_MANIFEST[FALLBACK_KEY]
+}
+
+export const getPortraitSourceFromValues = (
+  ancestry: PortraitId["ancestry"],
+  classId: PortraitId["classId"],
+  genderId: PortraitId["genderId"],
+) => resolvePortraitSource(createPortraitId(ancestry, classId, genderId))

--- a/src/schema/character.ts
+++ b/src/schema/character.ts
@@ -4,11 +4,13 @@ import {
   abilityScoreKeys,
   classIds,
   defaultDiceExpression,
+  genderIds,
   raceIds,
   type RaceId,
   type AbilityScores,
   type ClassId,
   type CombatStats,
+  type GenderId,
 } from "../types/character"
 import {
   getClassDefaults,
@@ -61,6 +63,24 @@ export const characterIdentitySchema = z.object({
   background: z.string().min(1, "Background is required"),
   alignment: z.enum(alignmentOptions),
   playerName: z.string().min(1, "Player name is required"),
+  genderId: z.enum(genderIds),
+  customGenderLabel: z
+    .string()
+    .trim()
+    .max(60, "Keep custom gender labels concise")
+    .optional()
+    .nullable(),
+}).superRefine((value, ctx) => {
+  if (value.genderId === "custom") {
+    const label = value.customGenderLabel?.trim() ?? ""
+    if (!label) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["customGenderLabel"],
+        message: "Describe your gender when using the custom option",
+      })
+    }
+  }
 })
 
 export const classSelectionSchema = z
@@ -220,6 +240,7 @@ export type CharacterCombat = CharacterFormValues["combat"]
 const DEFAULT_LEVEL = 1
 const DEFAULT_CLASS_ID: ClassId = "fighter"
 const DEFAULT_RACE_ID: RaceId = "human"
+const DEFAULT_GENDER_ID: GenderId = "female"
 
 export const defaultCharacterIdentity: CharacterIdentity = {
   characterName: "",
@@ -228,6 +249,8 @@ export const defaultCharacterIdentity: CharacterIdentity = {
   background: "",
   alignment: "Unaligned",
   playerName: "",
+  genderId: DEFAULT_GENDER_ID,
+  customGenderLabel: "",
 }
 
 export type ClassSelection = z.output<typeof classSelectionSchema>

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -83,6 +83,45 @@ export interface SubclassOption {
   description?: string
 }
 
+export const genderIds = [
+  "female",
+  "male",
+  "nonbinary",
+  "custom",
+] as const
+
+export type GenderId = (typeof genderIds)[number]
+
+export const genderLabels: Record<Exclude<GenderId, "custom">, string> = {
+  female: "Female",
+  male: "Male",
+  nonbinary: "Nonbinary",
+}
+
+export interface CharacterGender {
+  id: GenderId
+  label: string
+}
+
+export const genderOptions: CharacterGender[] = [
+  { id: "female", label: genderLabels.female },
+  { id: "male", label: genderLabels.male },
+  { id: "nonbinary", label: genderLabels.nonbinary },
+  { id: "custom", label: "Custom (self-described)" },
+]
+
+export interface PortraitId {
+  ancestry: RaceId | null | undefined
+  classId: ClassId | null | undefined
+  genderId: GenderId | null | undefined
+}
+
+export const createPortraitId = (
+  ancestry: RaceId | null | undefined,
+  classId: ClassId | null | undefined,
+  genderId: GenderId | null | undefined,
+): PortraitId => ({ ancestry, classId, genderId })
+
 export type SpellcastingStyle = "prepared" | "spells_known" | "pact"
 
 export interface SpellcastingMeta {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    globals: false,
+    watch: false,
+  },
+})


### PR DESCRIPTION
## Summary
- allow class-only portraits to resolve when ancestry-specific art is missing
- cover the class fallback logic with a resolver regression test
- replace portrait binaries with inline SVG placeholders and document the new asset workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e9a8ae4920832987f64348c735c2aa