### PR TITLE
docs: sync guides with portrait and class flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A React + TypeScript application for crafting richly themed Dungeons & Dragons c
 - React Hook Form + Zod schema defining character identity and ability score structure.
 - Modular component layout (identity, combat readiness, ability roller, live score grid) ready for upcoming spellbook and equipment sections.
 - Styling tuned for a parchment-inspired interface with responsive panels and reusable field primitives.
+- Character portrait hero panel that swaps artwork based on ancestry, class, and gender selections with graceful fallbacks.
+- Class selection flow including subclasses, fighting styles, and prepared spell toggles that feed combat defaults.
 
 ## Getting Started
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,11 +15,13 @@ src/
   App.css                # Global panel + field styling
   components/
     CharacterIdentitySection.tsx
+    CharacterPortrait.tsx
     ClassSelectionSection.tsx
     CombatStatsSection.tsx
   lib/
     classes.ts           # Class metadata, helpers for defaults & summaries
     dice.ts              # Dice parsing, RNG helpers, method metadata
+    portraits.ts         # Portrait manifest + ancestry/class/gender resolver
   schema/
     character.ts         # Zod schema, defaults, alignment/combat options
   types/
@@ -32,6 +34,7 @@ Public assets live in `public/`; Vite handles asset inlining under `src/assets/`
 
 `App.tsx` wraps the sheet in `FormProvider`, exposing:
 
+- **CharacterPortrait** – Displays ancestry/class/gender-aware art resolved via `lib/portraits`, with loading skeletons and optional attribution.
 - **CharacterIdentitySection** – Captures name, level, ancestry, background, alignment, and player info. Uses datalists for quick suggestions and displays inline validation.
 - **ClassSelectionSection** – Presents a SRD-compliant class list, subclass picker, prepared-spell toggle, and fighting style radios backed by class metadata. Emits helper text describing hit dice, primary abilities, and saving throws.
 - **CombatStatsSection** – Collects AC, initiative bonus, speed, hit points, and hit dice with bounded numeric inputs, plus class-aware recommendations and an "apply defaults" action.
@@ -61,6 +64,12 @@ Every panel uses the shared `panel` styling for a consistent parchment card aest
 - Supported methods: `custom_expression`, `four_d6_drop_lowest`, `three_d6`, `three_d6_reroll_ones`.
 - Expression parser accepts additive/subtractive chains (e.g. `2d6+1d4+3`) with guardrails (`MAX_DICE_COUNT`, `MAX_DICE_SIDES`).
 - `isDiceExpressionValid` underpins schema refinements and UI validation, while `rollAbilityScores` outputs an `AbilityScores` map keyed by ability.
+
+`lib/portraits.ts` owns the ancestry/class/gender portrait resolver:
+
+- `PORTRAIT_MANIFEST` maps identifier tuples to static assets in `public/portraits/`.
+- `resolvePortraitSource` walks through fallback combinations (triple match → ancestry/gender → class/gender → single ancestry/class → global default).
+- `getPortraitSourceFromValues` bridges raw form selections to the resolver for ease of use in components and tests.
 
 ## Styling System
 


### PR DESCRIPTION
## Summary
- highlight the portrait hero and class selection flows in the README project overview
- document the CharacterPortrait component and portraits utility in the architecture guide so both merged features are represented together

## Testing
- npm run build
- npm run test *(fails: local vitest binary is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea73a9e4f883298b20ea91f4592eb0