### PR TITLE
fix: set Vite base for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,11 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
+const isProduction = process.env.NODE_ENV === 'production'
+
 export default defineConfig({
   plugins: [react()],
-  base: '/',
+  base: isProduction ? '/DungeonsAndDragons/' : '/',
   build: {
     outDir: 'dist',
     assetsDir: 'assets',


### PR DESCRIPTION
## Summary
- configure the Vite base path to use the repository subdirectory during production builds so GitHub Pages assets load correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ebb565373883298eac0d62fe53fad6