### PR TITLE
Fix dice parser validation for malformed constants

### DIFF
--- a/src/lib/dice.test.ts
+++ b/src/lib/dice.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+import { isDiceExpressionValid, parseDiceExpression } from "./dice"
+
+describe("parseDiceExpression", () => {
+  it("rejects constants containing stray characters", () => {
+    expect(parseDiceExpression("1d")).toBeNull()
+    expect(parseDiceExpression("2+1d")).toBeNull()
+  })
+
+  it("parses valid expressions", () => {
+    expect(parseDiceExpression("2d6+3")).not.toBeNull()
+  })
+})
+
+describe("isDiceExpressionValid", () => {
+  it("mirrors parse validation for malformed constants", () => {
+    expect(isDiceExpressionValid("1d")).toBe(false)
+    expect(isDiceExpressionValid("2+1d")).toBe(false)
+    expect(isDiceExpressionValid("4d6-2")).toBe(true)
+  })
+})

--- a/src/lib/dice.ts
+++ b/src/lib/dice.ts
@@ -129,6 +129,10 @@ export const parseDiceExpression = (expression: string): ParsedDiceExpression | 
       continue
     }
 
+    if (!/^\d+$/.test(token)) {
+      return null
+    }
+
     const constantValue = Number.parseInt(token, 10)
     if (!Number.isFinite(constantValue)) {
       return null


### PR DESCRIPTION
## Summary
- reject dice expression constant terms that contain non-numeric characters
- add regression tests covering malformed constants in the dice parser

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ebb81bb0a48329a8492a12e5d65275